### PR TITLE
mySQLi is Not Listed In Install Fix

### DIFF
--- a/phpBB/install/install.php
+++ b/phpBB/install/install.php
@@ -342,9 +342,9 @@ $available_dbms = array(
 		'COMMENTS'		=> 'remove_remarks'
 	), 
 	'mysqli' => array(
-		'LABEL'			=> 'MySQL 4.x/5.x',
-		'SCHEMA'		=> 'mysql', 
-		'DELIM'			=> ';', 
+		'LABEL'			=> 'MySQLi',
+		'SCHEMA'		=> 'mysql',
+		'DELIM'			=> ';',
 		'DELIM_BASIC'	=> ';',
 		'COMMENTS'		=> 'remove_remarks'
 	), 
@@ -796,8 +796,8 @@ else
 			case 'mysql':
 			case 'mysql4':
 			case 'mysqli':
-				$check_exts = 'mysql';
-				$check_other = 'mysql';
+				$check_exts = 'mysqli';
+				$check_other = 'mysqli';
 				break;
 
 			case 'postgres':


### PR DESCRIPTION
I was able to have the mySQLi show up as an option in the install in php 7 Also I was able to verify after my change to the install file that the install still worked on php5 I could not go back any further. 